### PR TITLE
Make serviceAccount metadata configurable

### DIFF
--- a/prometheus-yace-exporter/README.md
+++ b/prometheus-yace-exporter/README.md
@@ -68,6 +68,8 @@ The following table lists the configurable parameters of the YACE Exporter chart
 | `rbac.create`                     | If true, create & use RBAC resources                                    | `false`                     |
 | `serviceAccount.create`           | Specifies whether a service account should be created.                  | `true`                      |
 | `serviceAccount.name`             | Name of the service account.                                            |                             |
+| `serviceAccount.annotations`      | Custom annotations for service                                          | `{}`                        |
+| `serviceAccount.labels`           | Additional custom labels for the service                                | `{}`                        |
 | `tolerations`                     | Add tolerations                                                         | `[]`                        |
 | `nodeSelector`                    | node labels for pod assignment                                          | `{}`                        |
 | `affinity`                        | node/pod affinities                                                     | `{}`                        |

--- a/prometheus-yace-exporter/templates/serviceaccount.yaml
+++ b/prometheus-yace-exporter/templates/serviceaccount.yaml
@@ -8,4 +8,13 @@ metadata:
     helm.sh/chart: {{ include "prometheus-yace-exporter.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+  {{- range $key, $val := .Values.serviceAccount.labels }}
+    {{ $key }}: {{ $val | quote }}
+  {{- end }}
+  {{- if .Values.serviceAccount.annotations
+  annotations:
+  {{- range $key, $val := .Values.serviceAccount.annotations }}
+    {{ $key }}: {{ $val | quote }}
+  {{- end }}
+  {{- end }}
 {{- end }}

--- a/prometheus-yace-exporter/templates/serviceaccount.yaml
+++ b/prometheus-yace-exporter/templates/serviceaccount.yaml
@@ -11,7 +11,7 @@ metadata:
   {{- range $key, $val := .Values.serviceAccount.labels }}
     {{ $key }}: {{ $val | quote }}
   {{- end }}
-  {{- if .Values.serviceAccount.annotations
+  {{- if .Values.serviceAccount.annotations }}
   annotations:
   {{- range $key, $val := .Values.serviceAccount.annotations }}
     {{ $key }}: {{ $val | quote }}

--- a/prometheus-yace-exporter/values.yaml
+++ b/prometheus-yace-exporter/values.yaml
@@ -69,6 +69,8 @@ aws:
 serviceAccount:
   # Specifies whether a ServiceAccount should be created
   create: true
+  annotations: {}
+  labels: {}
   # The name of the ServiceAccount to use.
   # If not set and create is true, a name is generated using the fullname template
   name:


### PR DESCRIPTION
Give the ability to specify labels and/or annotations to a serviceAccount. This is very useful for example when using AWS EKS and iRSA, in order to specify the role ARN via serviceAccount annotation.