### PR TITLE
Use tpl function to create config.yml configmap

### DIFF
--- a/prometheus-yace-exporter/Chart.yaml
+++ b/prometheus-yace-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.13.7"
 description: A Helm chart for YACE exporter
 name: prometheus-yace-exporter
-version: 0.3.2
+version: 0.3.3
 home: https://github.com/ivx/yet-another-cloudwatch-exporter
 sources:
 - https://github.com/ivx/yet-another-cloudwatch-exporter

--- a/prometheus-yace-exporter/templates/configmap.yaml
+++ b/prometheus-yace-exporter/templates/configmap.yaml
@@ -9,4 +9,4 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 data:
   config.yml: |
-{{ printf .Values.config | indent 4 }}
+{{- (tpl .Values.config $) | nindent 4 }}


### PR DESCRIPTION
Hey @mogaal - thanks for taking the time to create and maintain this chart.

I think it would be useful to use the [`tpl` function](https://helm.sh/docs/howto/charts_tips_and_tricks/#using-the-tpl-function) to create the configmap.

In my scenario, I have YACE deployed to multiple environments. I have a library chart which depends on this one containing common config.

It would be useful to be able to interpolate values into the common config e.g:

```yaml
prometheus-yace-exporter:
  config: |-
      jobs:
      - type: elb
        regions:
          - eu-west-1
        searchTags:
          - key: KubernetesCluster
            value: {{ .Values.aws.searchTags.KubernetesCluster }}
```

This avoids having to copy and paste the entire config for each environment and just set the values as needed.

Many thanks!
