### PR TITLE
flag provided but not defined: -scrape-interval

### DIFF
--- a/prometheus-yace-exporter/values.yaml
+++ b/prometheus-yace-exporter/values.yaml
@@ -56,7 +56,7 @@ podLabels: {}
 
 extraArgs: []
 #   decoupled-scraping: false
-#   scrape-interval: 300
+#   scraping-interval: 300
 
 
 aws:


### PR DESCRIPTION
flag provided but not defined: -scrape-interval
Usage of yace:
  -scraping-interval int
        Seconds to wait between scraping the AWS metrics if decoupled scraping. (default 300)