### PR TITLE
Add imagePullSecrets to deployment

### DIFF
--- a/prometheus-yace-exporter/Chart.yaml
+++ b/prometheus-yace-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.13.7"
 description: A Helm chart for YACE exporter
 name: prometheus-yace-exporter
-version: 0.5.0
+version: 0.5.1
 home: https://github.com/ivx/yet-another-cloudwatch-exporter
 sources:
 - https://github.com/ivx/yet-another-cloudwatch-exporter

--- a/prometheus-yace-exporter/templates/deployment.yaml
+++ b/prometheus-yace-exporter/templates/deployment.yaml
@@ -28,7 +28,7 @@ spec:
         {{ $key }}: {{ $val | quote }}
       {{- end}}
     spec:
-    {{- with .Values.imagePullSecrets }}
+    {{- with .Values.image.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
     {{- end }}

--- a/prometheus-yace-exporter/templates/deployment.yaml
+++ b/prometheus-yace-exporter/templates/deployment.yaml
@@ -28,6 +28,10 @@ spec:
         {{ $key }}: {{ $val | quote }}
       {{- end}}
     spec:
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/prometheus-yace-exporter/values.yaml
+++ b/prometheus-yace-exporter/values.yaml
@@ -8,6 +8,7 @@ image:
   repository: quay.io/invisionag/yet-another-cloudwatch-exporter
   tag: v0.13.7
   pullPolicy: IfNotPresent
+  imagePullSecrets: []
 
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
Adds the ability to specify imagePullSecrets for the deployment resource. This enables the ability to easily pull from private docker repositories.