### PR TITLE
Support metricRelabelings

### DIFF
--- a/prometheus-yace-exporter/templates/servicemonitor.yaml
+++ b/prometheus-yace-exporter/templates/servicemonitor.yaml
@@ -19,6 +19,10 @@ spec:
 {{- if .Values.serviceMonitor.telemetryPath }}
     path: {{ .Values.serviceMonitor.telemetryPath }}
 {{- end }}
+{{- if .Values.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+{{ toYaml .Values.serviceMonitor.metricRelabelings | indent 4 }}
+{{- end }}
 {{- if .Values.serviceMonitor.timeout }}
     scrapeTimeout: {{ .Values.serviceMonitor.timeout }}
 {{- end }}


### PR DESCRIPTION
The Exporter should be relatively invisible.  Our infrastructure wants to tag the exported cloudwatch metrics with details from the container where yace is running (e.g. container, cluster, pod, instance, job, &c).  Adding this feature to the serviceMonitor template allows us to pass in `metricRelabelings` that perform `labeldrop`.

```
 metricRelabelings:
 - action: labeldrop
   regex: pod
```